### PR TITLE
WIP: add some test_utils to experiment with

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ _scrapes/
 .coverage
 htmlcov/
 site/
+_test_responses/

--- a/src/spatula/sources.py
+++ b/src/spatula/sources.py
@@ -41,7 +41,7 @@ class URL(Source):
 
     def get_response(
         self, scraper: scrapelib.Scraper
-    ) -> Optional[requests.models.Response]:
+    ) -> requests.models.Response:
         return scraper.request(
             method=self.method,
             url=self.url,

--- a/src/spatula/test_utils.py
+++ b/src/spatula/test_utils.py
@@ -1,0 +1,116 @@
+import json
+import os
+import re
+import requests
+import scrapelib
+import warnings
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Optional
+from .pages import Page
+from .sources import URL
+
+
+class SpatulaTestError(Exception):
+    pass
+
+
+@dataclass
+class MockResponse:
+    content: bytes
+
+    def json(self):
+        return json.loads(self.content)
+
+    @property
+    def text(self):
+        return self.content
+
+
+class CachedTestURL(URL):
+    def __init__(
+        self,
+        url: str,
+        method: str = "GET",
+        data: dict = None,
+        headers: dict = None,
+        verify: bool = True,
+        timeout: Optional[float] = None,
+        retries: Optional[int] = None,
+    ):
+        """
+        Defines a resource to fetch via URL, particularly useful for handling non-GET
+        requests.
+
+        :param url: URL to fetch
+        :param method: HTTP method to use, defaults to "GET"
+        :param data: POST data to include in request body.
+        :param headers: dictionary of HTTP headers to set for the request.
+        :param verify: bool indicating whether or not to verify SSL certificates for request, defaults to True
+        :param timeout: HTTP(S) timeout in seconds
+        :param retries: number of retries to make
+        """
+
+        self.url = url
+        self.method = method
+        self.data = data
+        self.headers = headers
+        self.verify = verify
+        self.timeout = timeout
+        self.retries = retries
+
+    @classmethod
+    def from_url(cls, url: URL | str) -> "CachedTestURL":
+        if isinstance(url, str):
+            url = URL(url)
+        return cls(
+            url=url.url,
+            method=url.method,
+            data=url.data,
+            headers=url.headers,
+            verify=url.verify,
+            timeout=url.timeout,
+            retries=url.retries,
+        )
+
+    def get_response(
+        self, scraper: scrapelib.Scraper
+    ) -> Optional[requests.models.Response]:
+        path = _source_to_test_path(self)
+        if path.exists():
+            return MockResponse(path.read_text())
+        else:
+            if os.environ.get("SPATULA_TEST_ALLOW_FETCH") == "1":
+                warnings.warn(f"spatula test fetching {self} -> {path}")
+                response = super().get_response(scraper)
+                if not path.parent.exists():
+                    path.parent.mkdir()
+                with path.open("w") as cf:
+                    cf.write(response.text)
+                    return MockResponse(response.text)
+            else:
+                warnings.warn("Set SPATULA_TEST_ALLOW_FETCH=1 to allow fetching.")
+                raise SpatulaTestError(f"spatula test missing {self} @ {path}")
+
+    def __repr__(self) -> str:
+        return f"CachedTestURL({self.url})"
+
+
+def _source_to_test_path(source: URL) -> Path:
+    # TODO: do this the right way
+    clean_url = re.sub(r"[:/]", "_", source.url)
+    return Path(__file__).parent / "_test_responses" / clean_url
+
+
+def cached_page_response(page: Page):
+    scraper = scrapelib.Scraper()
+    page.source = CachedTestURL.from_url(page.source)
+    page._fetch_data(scraper)
+    page.postprocess_response()
+    return page
+
+
+def cached_page_items(page: Page):
+    page.source = CachedTestURL.from_url(page.source)
+    items = list(page.do_scrape())
+    return items

--- a/src/spatula/test_utils.py
+++ b/src/spatula/test_utils.py
@@ -6,7 +6,7 @@ import scrapelib
 import warnings
 from dataclasses import dataclass, asdict
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 from .pages import Page
 from .sources import URL
 
@@ -48,7 +48,7 @@ class CachedTestURL(URL):
         self.retries = retries
 
     @classmethod
-    def from_url(cls, url: URL | str) -> "CachedTestURL":
+    def from_url(cls, url: Union[URL, str]) -> "CachedTestURL":
         if isinstance(url, str):
             url = URL(url)
         return cls(


### PR DESCRIPTION
Aims to address #37 
`CachedTestURL` is the workhorse here, it replaces URL (and can be hot swapped in for it) and instead of always making a request, it favors a locally cached copy.  These copies could be generated manually, but there is also an environment variable that will tell spatula to fetch them if they are missing.

Right now it takes the same properties as URL, but could be extended to take response text as suggested in #37 
(Also, needs to use all properties of request/response in caching.)

This branch also adds two helper methods so people don't have to work with this directly if they don't want to:

- `cached_page_response(page: Page) -> Page` - returns a page where a request has already been made using `CachedTestURL` -- allowing you to call methods on your page object as if you're inside of `do_scrape`
- `cached_page_items(page: Page) -> list[item]` - returns the result of `do_scrape` collected into a list